### PR TITLE
Potential fix for code scanning alert no. 60: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/users-sequelize.mjs
+++ b/Chapter14/users/users-sequelize.mjs
@@ -90,7 +90,12 @@ export async function findOneUser(username) {
 
 export async function createUser(req) {
     let tocreate = userParams(req);
-    console.log(`create tocreate ${util.inspect(tocreate)}`);
+    // Avoid logging sensitive information such as password
+    let logTocreate = { ...tocreate };
+    if (logTocreate.password !== undefined) {
+        logTocreate.password = '[REDACTED]';
+    }
+    console.log(`create tocreate ${util.inspect(logTocreate)}`);
     await SQUser.create(tocreate);
     const result = await findOneUser(req.params.username);
     return result;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/60](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/60)

The problem is that the code logs the entire `tocreate` object, which contains a plain-text password as part of the log message. To fix this:

- Avoid logging sensitive data such as passwords. If logging of user creation is necessary for debugging/auditing, sanitize the log entry by excluding sensitive fields like `password` before logging.
- The best approach is to create a shallow copy of the object, remove or mask the `password` field, and then log only the sanitized version.
- The edit should be applied directly to the logging line in the `createUser` function in `Chapter14/users/users-sequelize.mjs`. No new methods or third-party packages are needed since simple object copying and field omission can be achieved in-line.
- The log message will instead display the user creation parameters, but with the password omitted or replaced with a placeholder.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
