### PR TITLE
Potential fix for code scanning alert no. 59: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/users-sequelize.mjs
+++ b/Chapter14/users/users-sequelize.mjs
@@ -40,7 +40,12 @@ export async function connectDB() {
             && process.env.SEQUELIZE_DBDIALECT !== '') {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
-    log('Sequelize params '+ util.inspect(params));
+    // Avoid logging sensitive data such as the password
+    let logParams = { ...params };
+    if (logParams.password !== undefined) {
+        logParams.password = '[REDACTED]';
+    }
+    log('Sequelize params ' + util.inspect(logParams));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/59](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/59)

The best way to fix the problem is to redact or avoid logging sensitive fields before outputting them. In this specific file, we should make a shallow clone of `params`, replace the value of any sensitive fields (like `password`) with a redaction marker (e.g., `'[REDACTED]'`), and only then log the sanitized object. 

In `Chapter14/users/users-sequelize.mjs`, on line 43, change so that the password is redacted before logging the params. Also, while the primary concern is the password field (`params.password`), if the structure could contain other sensitive fields (such as secrets in `params.params`), it's a good practice to check and redact them as well, but based on the context shown, only `password` is sensitive in `params`.

No additional imports are needed, as the required utilities are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
