### PR TITLE
Potential fix for code scanning alert no. 58: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/user-server.mjs
+++ b/Chapter14/users/user-server.mjs
@@ -147,7 +147,7 @@ server.post('/password-check', async (req, res, next) => {
     try {
         await connectDB();
         const user = await SQUser.findOne({ where: { username: req.params.username } });
-        log(`userPasswordCheck query=${req.params.username} ${req.params.password} user=${user ? user.username : ''} ${user ? user.password : ''}`);
+        log(`userPasswordCheck query username=${req.params.username} user=${user ? user.username : ''}`);
         let checked;
         if (!user) {
             checked = { 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/58](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/58)

To fix the problem, we should remove any logging of sensitive data, specifically the password provided in `req.params.password` and the stored `user.password`, from all log statements. The line at issue (line 150) forms a log entry containing both the submitted password and the stored hashed password. The log should instead record only non-sensitive metadata, such as the username involved, and blur out or omit any reference to passwords. If logging is needed for debugging, replace the logged values with asterisks or generic phrases indicating a password was received, but *never* include cleartext passwords. Update the log statement at line 150 to exclude both `req.params.password` and `user.password`. Only log `user.username` and avoid logging any details about the password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
