### PR TITLE
Potential fix for code scanning alert no. 41: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/users/user-server.mjs
+++ b/Chapter12/users/user-server.mjs
@@ -9,6 +9,16 @@ import DBG from 'debug';
 const log = DBG('users:service'); 
 const error = DBG('users:error'); 
 
+// Helper to redact password from logged user params
+function sanitizeUserParams(params) {
+    if (!params || typeof params !== 'object') return params;
+    // clone and replace password
+    return {
+        ...params,
+        password: params.password !== undefined ? '***REDACTED***' : undefined,
+    };
+}
+
 import { default as bcrypt } from 'bcrypt';
 
 ///////////// Set up the REST server
@@ -66,7 +76,7 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        log(`updating ${util.inspect(sanitizeUserParams(toupdate))}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/41](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/41)

The fix is to ensure that the `password` field is never logged in cleartext as part of the `toupdate` or any user params objects. Instead, we should log a "sanitized" copy of the object, where `password` is either omitted or replaced with a redacted value (e.g., `"***REDACTED***"`). This approach preserves useful operational logging while avoiding cleartext exposure of sensitive data.

Best practice would be:
- Define a small helper to clone a user params object and mask/remove the `password` field.
- Apply this helper before passing user data objects to `log`, especially in code paths that currently log request body/params structures.
- Specifically, update line 69 in `user-server.mjs` (and optionally line 49 if it's logging passwords, but only line 69 is required by the alert) to log the sanitized object.

No new packages are required; this can be done inline in current files.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
