### PR TITLE
Potential fix for code scanning alert no. 78: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter14/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter14/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/78](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/78)

The best way to fix this issue is to avoid using untrusted user input directly as a jQuery selector. The `selector` variable comes from a data attribute and can contain malicious values interpretable as HTML by jQuery. Instead of using `$(selector)[0]`, use `document.querySelector(selector)` to get a DOM element safely (since it will only accept valid CSS selectors, not HTML), and then wrap that reference in `$()` only if it is non-null.

**Steps:**
- In the data API handler (`Carousel._dataApiClickHandler`), change `var target = $(selector)[0];` to instead use `document.querySelector(selector)` to resolve the element.
- If the result is not null, wrap the DOM element with `$()` as needed for subsequent operations.
- Do not use `$(selector)` directly with untrusted input.

You only need to change one line in `Carousel._dataApiClickHandler`—where `target` is assigned.  

No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
