### PR TITLE
Potential fix for code scanning alert no. 77: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter14/notes/theme/dist/js/bootstrap.js
+++ b/Chapter14/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/77](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/77)

To prevent jQuery from parsing untrusted DOM text as HTML or as a selector, we should only use selector strings as CSS selectors and not as HTML. The safest and recommended fix is to avoid using `$(selector)` directly, and instead only manipulate real DOM elements found safely via `document.querySelector()`. If you want to operate on it with jQuery, you should use the result (`element`) and wrap it with jQuery: `$(element)`.

Specifically:  
- In the method `Carousel._dataApiClickHandler`, replace `var target = $(selector)[0];` (lines 1153) with safe resolution:  
  - Find the real element using `document.querySelector(selector)`,  
  - Then wrap the result with `$()` if needed.  
This way, you never risk interpreting untrusted DOM text as HTML or as a jQuery selector.  
No imports or extra dependencies are needed; just change the reference so you only wrap real (safe) element objects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
