### PR TITLE
Potential fix for code scanning alert no. 75: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter13/notes/theme/dist/js/bootstrap.js
+++ b/Chapter13/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/75](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/75)

To eliminate the risk, do not pass the raw, possibly attacker-controlled selector string directly to `$()`. Instead, use `document.querySelector(selector)` (which is already done in `getSelectorFromElement` to check existence) and then wrap the returned DOM node with `$` if a jQuery object is desired. This approach guarantees that no HTML will be injected (because querySelector will only return an existing, legitimate DOM element or null), and also prevents any XSS or DOM clobbering via specially crafted selector strings.  

Specifically, in `Carousel._dataApiClickHandler`, on line 1153, replace `var target = $(selector)[0];` with:  
- `var target = document.querySelector(selector);`  
  then, everywhere `$(target)` is used, this is safe because `target` is a DOM element, not a string.  

Only change this specific instance — avoid making wide changes or altering other selector-handling code, staying within the provided snippets.

No new dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
