### PR TITLE
Potential fix for code scanning alert no. 76: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter13/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter13/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,9 +1149,9 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
-      if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
+      if (!target || !$(target).classList.contains(ClassName$2.CAROUSEL)) {
         return;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/76](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/76)

To fix this vulnerability, we must ensure that untrusted content from `data-target` is *never* passed directly to jQuery's `$` selector, since this can cause interpretation as HTML. The recommended solution is to use pure DOM APIs (e.g., `document.querySelector`) to resolve the selector, and then use jQuery on the obtained element, rather than rebuilding a jQuery object from a potentially untrusted selector.

The cleanest path is: in the Carousel `_dataApiClickHandler`, instead of
```js
var target = $(selector)[0];
```
use:
```js
var target = document.querySelector(selector);
```
and then, subsequently, use `$(target)` where a jQuery object is needed.

Before doing so, we must ensure that `selector` from `getSelectorFromElement` is guaranteed to return only a valid CSS selector or `null`. The existing implementation already does so using `document.querySelector`. So the main change is on line 1152, replace the use of `$(selector)[0]` with `document.querySelector(selector)`. This prevents jQuery from parsing HTML from attacker-controlled input.

No new imports are needed, as `document.querySelector` is available globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
