### PR TITLE
Potential fix for code scanning alert no. 74: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter12/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter12/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/74](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/74)

To fix the issue, we must ensure that any input used as a selector (extracted from `data-target` or `href`) is strictly validated, sanitized, or otherwise handled so that it cannot be used to inject or reinterpret untrusted text as HTML.

**Best fix approach:**
- When extracting selectors from attributes, ensure they are strictly CSS selectors (allow only ID or class selectors, for example).
- Explicitly forbid selectors that look like HTML (those starting with `<`) or ambiguous selectors.
- Alternatively, instead of passing the string directly to `$`, use DOM APIs to retrieve the element (e.g., `document.querySelector(selector)`), and then wrap the found element in jQuery: `$(element)`, not `$(selector)`.
- Make the replacement in the `Carousel._dataApiClickHandler` function at line 1152, changing:
    ```js
    var target = $(selector)[0];
    ```
  to:
    ```js
    var target = document.querySelector(selector);
    ```
  and use `$(target)` later, only if `target` is found.
- This way, even if the selector is malicious, the browser's selector engine (not jQuery's) is used, which does not interpret it as HTML and doesn't create elements.

**Implementation:**
- In `Carousel._dataApiClickHandler`, replace `var target = $(selector)[0];` with `var target = document.querySelector(selector);`.
- The usages of `$(target)` below remain valid, since `target` is a DOM node object.
- No need to modify the rest of the code since a null target (not found) is already handled.
- No new libraries/imports required.
- This should be changed in place, with context before/after the edit for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
