### PR TITLE
Potential fix for code scanning alert no. 73: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter12/notes/theme/dist/js/bootstrap.js
+++ b/Chapter12/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/73](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/73)

To fix the root issue, ensure that the value extracted from the `data-target` attribute is only used as a CSS selector, never as HTML or JavaScript. jQuery’s `$()` is dangerous if given unsanitized data, because it interprets strings as either selectors or HTML; to force selector-only parsing, use `document.querySelector` or jQuery’s `.find()` on an existing parent element. In this context, the best fix is to avoid passing the tainted `selector` string directly to `$()`. Instead, use `document.querySelector(selector)` to find the target element, and wrap that element in jQuery for further processing. This restricts the behavior to safe selector use and prevents HTML injection.

Edit file `Chapter12/notes/theme/dist/js/bootstrap.js`:
- In `Carousel._dataApiClickHandler`, change  
  `var target = $(selector)[0];`  
  to  
  `var target = document.querySelector(selector);`
- If target is truthy, wrap with `$(target)` for all subsequent uses.
- Optionally, clarify that selector is always handled as a CSS selector only.

No new imports or dependencies are required. All changes are limited to this event handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
