### PR TITLE
Potential fix for code scanning alert no. 8: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter09/notes/app.mjs
+++ b/Chapter09/notes/app.mjs
@@ -107,7 +107,8 @@ app.use(session({
     secret: sessionSecret,
     resave: true,
     saveUninitialized: true,
-    name: sessionCookieName
+    name: sessionCookieName,
+    cookie: { secure: true, httpOnly: true }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/8](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/8)

To fix this vulnerability, explicitly set the `secure` flag in the session cookie options within the Express session middleware configuration. This ensures that the session cookie is only sent over HTTPS connections. Additionally, setting `httpOnly: true` is recommended to prevent access to the cookie from JavaScript. The best practice is to set these attributes via the `cookie` property in the session options object.  
- Edit the session middleware configuration block (line 105+) in `Chapter09/notes/app.mjs`.  
- Set `cookie: { secure: true, httpOnly: true }` within the options object.  
- For maximum compatibility, you may wish to conditionally set `secure: true` only when running in production mode, but under the scope provided, we will set it unconditionally.  
No imports are needed, as the change is purely in configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
