### PR TITLE
Potential fix for code scanning alert no. 79: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/users-sequelize.mjs
+++ b/Chapter14/users/users-sequelize.mjs
@@ -41,11 +41,10 @@ export async function connectDB() {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
     // Avoid logging sensitive data such as the password
-    let logParams = { ...params };
-    if (logParams.password !== undefined) {
-        logParams.password = '[REDACTED]';
-    }
-    log('Sequelize params ' + util.inspect(logParams));
+    // Only log non-sensitive DB connection info for debugging
+    log('Sequelize DB connection: ' +
+        `dbname=${params.dbname}, user=${params.username}, host=${params.params?.host}, port=${params.params?.port}, dialect=${params.params?.dialect}`);
+    
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/79](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/79)

To fix the problem, we should remove or substantially minimize the logging of database connection parameters, especially avoiding any output of fields that might accidentally contain sensitive information in the future. Rather than logging the full connection parameter object (even with the password redacted), we can log only the safe, non-sensitive values that are useful for debugging, such as the dbname, user, host, port, and dialect, but *never* password/secret values. The edit should take place on or near line 48 of Chapter14/users/users-sequelize.mjs, replacing the `log('Sequelize params ' + util.inspect(logParams));` line with a safe, explicit log of only the non-sensitive subset of the configuration.

No additional library imports are necessary; changes are only needed in the relevant code region.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
