### PR TITLE
Potential fix for code scanning alert no. 71: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter11/notes/theme/dist/js/bootstrap.js
+++ b/Chapter11/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = $(document).find(selector)[0];
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/71](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/71)

To fix the problem, we must prevent tainted selector values from being interpreted directly as HTML by jQuery. The recommended pattern is to always perform selector lookups scoped to a known DOM element (using `.find(selector)`), rather than using the untrusted string with `$()`.

In this case, on line 1153,
```js
var target = $(selector)[0];
```
should be restructured so that `selector` is only interpreted as a CSS selector within a safe ancestor container using `.find()`. Because `selector` is expected to match elements on the page (typically by CSS selector/id), it's safer to scope the search (such as limiting to `document` or a known root). In jQuery, `$(document).find(selector)` is a common defensive pattern because jQuery's `.find()` does not interpret the argument as HTML.

**Detailed steps:**
- Replace `var target = $(selector)[0];` with `var target = $(document).find(selector)[0];`
- This ensures `selector` is always used only as a CSS selector, never as HTML, guarding against XSS.

No new imports or definitions are needed, as `$` (jQuery) is in scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
