### PR TITLE
Potential fix for code scanning alert no. 57: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/user-server.mjs
+++ b/Chapter14/users/user-server.mjs
@@ -66,7 +66,12 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        // Redact sensitive fields before logging
+        let logToupdate = { ...toupdate };
+        if (logToupdate.password !== undefined) {
+            logToupdate.password = '[REDACTED]';
+        }
+        log(`updating ${util.inspect(logToupdate)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/57](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/57)

To fix the problem, we need to prevent sensitive data such as passwords from being written to logs. The most robust way is to sanitize or redact sensitive fields before logging, replacing their values with a fixed placeholder (e.g., `[REDACTED]`). This can be implemented locally where the sensitive structure is logged. 

In the context of `server.post('/update-user/:username'...)`, after `let toupdate = userParams(req);`, you should create a shallow copy of `toupdate`, and if the `password` field exists, replace it with `[REDACTED]`, then log the sanitized object instead of `toupdate`. This approach is already used elsewhere in the codebase (see `createUser` in `users-sequelize.mjs`).

Summary of steps:
- In `user-server.mjs` at the `/update-user/:username` endpoint, replace the logging of `toupdate` with logging a sanitized copy with any `password` field redacted.
- No additional methods, dependencies, or imports are required; use the same pattern and utilities (like the spread operator) as already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
