### PR TITLE
Potential fix for code scanning alert no. 56: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/cli.mjs
+++ b/Chapter14/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/56](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/56)

To fix this issue, avoid logging sensitive information such as passwords. The fix is to change the logging statement such that the password is not output in any manner (not even masked or partially shown–the safest is to entirely omit it). You can still log that a password check is being performed for the given username, but omit the actual password. Only alter the logging behavior on the indicated line (line 175), and make sure not to alter the functional aspects of the CLI.

Specifics:
- In `Chapter14/users/cli.mjs`, locate line 175, the statement  
  `console.log(`password check ${username} ${password}`);`
- Replace this with a message that does NOT log the password, e.g.,  
  `console.log(`password check for ${username}`);`
- No new imports or further modifications are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
