### PR TITLE
Potential fix for code scanning alert no. 55: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/users/cli.mjs
+++ b/Chapter14/users/cli.mjs
@@ -127,7 +127,9 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        // Log object without sensitive fields (e.g., password)
+        const { password, ...topostSanitized } = topost;
+        console.log('update ', topostSanitized);
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/55](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/55)

The best fix is to avoid logging sensitive information entirely. In this context, we should not log the `password` field, and should be cautious about other potential sensitive fields as well (such as PII like email). 

The fix:
- When logging the `topost` object at line 130, we can redact or remove sensitive fields before logging.  
- The quickest and clearest fix is to create a sanitized copy of `topost` omitting the `password` property (and optionally other fields like emails, depending on security policy) and log that instead.  
- This change should be made at line 130 of `Chapter14/users/cli.mjs` only. No additional imports or external packages are required, as property omission can be handled inline.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
