### PR TITLE
Potential fix for code scanning alert no. 54: Clear-text logging of sensitive information

### DIFF
--- a/Chapter14/notes/routes/users.mjs
+++ b/Chapter14/notes/routes/users.mjs
@@ -116,7 +116,7 @@ if (typeof process.env.TWITTER_CONSUMER_KEY !== 'undefined'
 
 if (twitterLogin) {
 
-    console.log(`enable_twitter consumer_key ${consumer_key} consumer_secret ${consumer_secret} ${twittercallback}/users/auth/twitter/callback`);
+    console.log(`enable_twitter configured with callback URL: ${twittercallback}/users/auth/twitter/callback`);
     passport.use(new TwitterStrategy({
         consumerKey: consumer_key,
         consumerSecret: consumer_secret,


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/54](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/54)

The best way to fix the issue is to stop logging any sensitive data such as API keys or secrets in cleartext. On line 119, the code currently outputs the values for `consumer_key` and `consumer_secret` to the log, which are considered sensitive. Instead, you should only log non-sensitive data, for example, indicating that Twitter login is enabled and the callback URL being used.

To implement this fix, simply remove `${consumer_key}` and `${consumer_secret}` from the logged message at line 119. You can, for example, log "enable_twitter configured with callback URL: ..." instead to avoid leaking credentials. No other lines or logic need to be modified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
