### PR TITLE
Potential fix for code scanning alert no. 9: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter10/notes/app.mjs
+++ b/Chapter10/notes/app.mjs
@@ -95,7 +95,10 @@ app.use(session({
     secret: sessionSecret,
     resave: true,
     saveUninitialized: true,
-    name: sessionCookieName
+    name: sessionCookieName,
+    cookie: {
+        secure: process.env.NODE_ENV === 'production'
+    }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/9](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/9)

To fix this issue, you should specify the `cookie` option in your session middleware configuration and set `secure: true`, ensuring the cookie is only set over HTTPS. Since this can cause issues in development where HTTPS may not be in use, a robust solution is to set `secure: process.env.NODE_ENV === 'production'` (secure only in production). You may also want to explicitly set the `httpOnly: true` attribute for additional protection, though this is not strictly necessary for this finding.

Edit the `session` middleware initialization at line 93 in `Chapter10/notes/app.mjs` to include:
```js
cookie: { 
    secure: process.env.NODE_ENV === 'production'
}
```
Add this object to the middleware options, making sure not to alter the other existing options.

No additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
