### PR TITLE
Potential fix for code scanning alert no. 66: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter08/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter08/notes/theme/dist/js/bootstrap.bundle.js
@@ -1145,11 +1145,13 @@
     Carousel._dataApiClickHandler = function _dataApiClickHandler(event) {
       var selector = Util.getSelectorFromElement(this);
 
-      if (!selector) {
+      if (!selector || typeof selector !== 'string' || selector.trim().charAt(0) === '<') {
+        // If selector is missing or looks like HTML, do not proceed
         return;
       }
 
-      var target = $(selector)[0];
+      // Use document.querySelector to safely select the target element
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/66](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/66)

To address this vulnerability, we must avoid passing untrusted DOM-provided strings from `data-target` (obtained via `element.getAttribute('data-target')`) directly to jQuery's `$` function, since `$` will interpret strings starting with `<` as HTML to be injected. Instead, the safest and idiomatic way is to only use strict CSS selectors and to use methods that treat the input exclusively as selectors, never as HTML.

In the location where `selector` is used, replace `$(selector)[0]` with `document.querySelector(selector)` to retrieve the element matching the selector as a DOM Node, or use jQuery's `find()` if within a known parent, or otherwise ensure that the selector can never be interpreted as HTML.  
Alternatively, to preserve use of jQuery and keep code logic unchanged, we can explicitly reject selector values that start with `<`, as those would be interpreted by jQuery as HTML, and bail out if such a value is encountered.

**Best fix:**  
Update the relevant region (in `Carousel._dataApiClickHandler`), after retrieving the `selector` string, to explicitly validate that `selector` does not start with `<`, and only pass it to `$` if safe, otherwise abort. Optionally, use `document.querySelector` instead of jQuery for selecting the target element, then pass that element (not the string) into jQuery.

**What to change:**  
- In `Carousel._dataApiClickHandler`, after `var selector = Util.getSelectorFromElement(this);`, check that `typeof selector === "string"` and that `!selector.trim().startsWith("<")`.
- Replace `$(selector)[0];` with a call to `document.querySelector(selector);`
- Pass the DOM element reference to jQuery instead of the string (`$(target)` with `target` being the DOM Node, not a string).

**No extra dependencies** are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
