### PR TITLE
Potential fix for code scanning alert no. 61: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter06/notes/theme/dist/js/bootstrap.js
+++ b/Chapter06/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/61](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/61)

The way to fix this is to avoid passing untrusted attribute values directly to jQuery's `$()` function, which can interpret selectors as HTML and potentially execute code. The safe alternative is to select elements only in a scoped and secure way—such as restricting lookups to descendant elements using `$.find(selector)` (scoped to `document` or a trusted parent), or better, only allowing selectors that strictly match an ID or class name. In Bootstrap 4, a more robust fix is to require that `data-target` only use a hashed ID selector (e.g., `#someId`), and to retrieve the DOM node directly (not via `$()` from a string), i.e., use `document.querySelector` instead of `$(selector)`.

Therefore, in the vulnerable region (line 1153), replace:
```js
var target = $(selector)[0];
```
with:
```js
var target = document.querySelector(selector);
```
This ensures only legitimate CSS selectors (subject to `querySelector` restrictions, robustly checked just above), and never interprets the string as HTML.

Elsewhere, make sure all downstream code that expects `target` to be a DOM element rather than a jQuery object works as expected (e.g., `$(target)` is safe).

No new dependencies are needed, and this change should not significantly alter intended functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
