### PR TITLE
Potential fix for code scanning alert no. 64: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter07/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter07/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/64](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/64)

The best remediation is to ensure that the selector string sourced from `data-target` cannot be used by jQuery to create arbitrary HTML or execute code. Rather than using `$(selector)` which both interprets selectors and can create elements from arbitrary HTML, it's safer to use native DOM queries (`document.querySelector`) or jQuery's `.find()` method on a known ancestor, so the string is only ever interpreted as a selector within a limited context (not as HTML). The fix involves specifically replacing `var target = $(selector)[0];` with a safer alternative. Since the usage pattern often is to resolve a selector relative to `document`, the best option is to use `document.querySelector(selector)`, which only matches selectors inside the document and never creates HTML or executes JS. We update line 1152 in `Chapter07/notes/theme/dist/js/bootstrap.bundle.js` (and further usages as needed) so that `target` is assigned via `document.querySelector(selector)` instead of `$(selector)[0]`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
