### PR TITLE
Potential fix for code scanning alert no. 63: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter06/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter06/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/63](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/63)

To fix the problem, we must prevent the tainted string from being interpreted as HTML or a script by jQuery, reducint XSS risk. The safest way is to avoid passing user-controllable strings to jQuery directly as selectors or HTML. Instead, use native DOM methods such as `document.querySelector`, and then operate on the result. In the code, instead of `var target = $(selector)[0];`, we should do:

- Use `document.querySelector(selector)` to obtain the element safely.
- Pass the native element directly to jQuery (as in `$(target)`), which is safe.
- Add a check to ensure `selector` is a valid CSS selector (not arbitrary HTML).

This change should be made at line 1152 of `Chapter06/notes/theme/dist/js/bootstrap.bundle.js`, replacing `var target = $(selector)[0];` with a variant that calls `document.querySelector`, and then passes the result to jQuery. Provide enough context for safe replacement. No additional methods or imports are needed, as DOM and jQuery are already used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
