### PR TITLE
Potential fix for code scanning alert no. 62: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter07/notes/theme/dist/js/bootstrap.js
+++ b/Chapter07/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/62](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/62)

To fix this issue safely, we must ensure that attacker-controllable text is *not* reinterpreted as HTML when passed to jQuery. For selector strings, best practice is to use the context-specific `.find()` method, which interprets its argument *only* as a selector, never as HTML. Instead of `$(selector)`, which might parse a string as HTML and inject code, we can use a root node (such as `document`) and call `.find(selector)`, or ideally resolve the node beforehand and operate on that directly.

The cleanest fix is to, after validating the selector, obtain the referenced DOM element using `document.querySelector(selector)` and then wrap it with `$()` for further processing, rather than passing the tainted selector string to `$()`. This means replacing:

```js
var target = $(selector)[0];
```

with:

```js
var target = document.querySelector(selector);
```

and using `$(target)` thereafter. This is safe, as it does not allow HTML to be injected as part of the jQuery processing.

**Edits to make:**  
- In the `_dataApiClickHandler` method (line 1146–1174), change:
  - The assignment: `var target = $(selector)[0];` → `var target = document.querySelector(selector);`
  - No other references to `selector` should need to change.
- No new imports or methods are needed; just change how the target is selected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
