### PR TITLE
Potential fix for code scanning alert no. 65: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter08/notes/theme/dist/js/bootstrap.js
+++ b/Chapter08/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/65](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/65)

**General fix:**  
Do not pass untrusted strings directly to the jQuery `$()` function. Instead, query DOM elements in a way that does not interpret untrusted input as HTML or a selector that could have side effects. For this use-case, use the standard DOM API (`document.querySelector`) to resolve the element, and then wrap the resolved element in a jQuery object for further manipulation.

**Best specific fix:**  
On line 1153, instead of:
```js
var target = $(selector)[0];
```
Use:
```js
var target = document.querySelector(selector);
```
Then, where `$(target)` is used, continue as is since `target` is now a DOM element (so `$(target)` is safe).

This ensures the string is interpreted strictly as a CSS selector (not HTML), and no jQuery parsing occurs on the raw string, eliminating the XSS risk.

**Detailed steps:**
- **Edit**: In the file `Chapter08/notes/theme/dist/js/bootstrap.js`, modify the assignment of `target` in `Carousel._dataApiClickHandler` to use `document.querySelector(selector)` instead of `$(selector)[0]`.
- **Check**: Downstream uses of `target` (already called as `$(target)`) need no change since it's now always a DOM node.

No new imports or additional definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
