### PR TITLE
Potential fix for code scanning alert no. 52: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/users/users-sequelize.mjs
+++ b/Chapter13/users/users-sequelize.mjs
@@ -90,7 +90,9 @@ export async function findOneUser(username) {
 
 export async function createUser(req) {
     let tocreate = userParams(req);
-    console.log(`create tocreate ${util.inspect(tocreate)}`);
+    // Redact password before logging
+    let redacted = { ...tocreate, password: '[REDACTED]' };
+    console.log(`create tocreate ${util.inspect(redacted)}`);
     await SQUser.create(tocreate);
     const result = await findOneUser(req.params.username);
     return result;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/52](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/52)

To fix the problem, we should prevent the logging statement from printing sensitive fields, specifically the password, in clear text. The best solution is to sanitize or redact the sensitive value before logging. Since the purpose of the log line appears to be for debugging, we can modify the code so that it creates a copy of `tocreate` with the password field removed or replaced by a placeholder (e.g., `"[REDACTED]"`). This will preserve relevant debugging information without leaking the password.

**Detailed steps:**
- Edit the logging in line 93 to log a redacted version of `tocreate`.
- Implement redaction inline before logging, or create a utility function for this if repeated elsewhere.
- No external dependencies are needed; we can use standard JS/Node functionality.
- Only code within the provided snippet should be edited.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
