### PR TITLE
Potential fix for code scanning alert no. 50: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/users/user-server.mjs
+++ b/Chapter13/users/user-server.mjs
@@ -147,7 +147,7 @@ server.post('/password-check', async (req, res, next) => {
     try {
         await connectDB();
         const user = await SQUser.findOne({ where: { username: req.params.username } });
-        log(`userPasswordCheck query=${req.params.username} ${req.params.password} user=${user ? user.username : ''} ${user ? user.password : ''}`);
+        log(`userPasswordCheck query=${req.params.username} user=${user ? user.username : ''}`);
         let checked;
         if (!user) {
             checked = { 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/50](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/50)

To fix the problem, avoid logging sensitive data such as plaintext passwords or password hashes. The problematic line is at line 150, where both `req.params.password` and `user.password` are included in the debug message. The safest and simplest fix is to log only non-sensitive data (e.g., the username) and redact or remove the sensitive parts from the message.

**Implementation:**
- Remove `req.params.password` and `user.password` from the log statement at line 150.
- If additional context is desired, log only the username being checked and whether a database record was found.
- There is no need for additional imports or method changes.
- Make the changes only in the file `Chapter13/users/user-server.mjs` at the location of the log statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
