### PR TITLE
Potential fix for code scanning alert no. 48: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/users/cli.mjs
+++ b/Chapter13/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for user ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/48](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/48)

To fix the issue, we need to ensure that the password is not logged to the console during a password check. The relevant code is in the handler for the `password-check <username> <password>` command, specifically at line 175. Remove `${password}` from the log statement so only the username (or a generic message) is logged. We can change the log to: ``console.log(`password check for user ${username}`);``. There is no need for additional imports or definitions; just a minor code edit in the log statement.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
