### PR TITLE
Potential fix for code scanning alert no. 46: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/notes/routes/users.mjs
+++ b/Chapter13/notes/routes/users.mjs
@@ -112,7 +112,7 @@ if (typeof process.env.TWITTER_CONSUMER_KEY !== 'undefined'
 
 if (twitterLogin) {
 
-    console.log(`enable_twitter consumer_key ${consumer_key} consumer_secret ${consumer_secret} ${twittercallback}/users/auth/twitter/callback`);
+    console.log(`enable_twitter enabled, callback URL: ${twittercallback}/users/auth/twitter/callback`);
     passport.use(new TwitterStrategy({
         consumerKey: consumer_key,
         consumerSecret: consumer_secret,


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/46](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/46)

To address the issue, the log statement at line 115 should be modified so that it does **not** log the sensitive `consumer_key` and `consumer_secret` values. Instead, the log message can simply state that Twitter login is being enabled, along with the callback URL, which is fine to log. The value of these credentials should not appear in logs under any circumstance.  
- Only change the log message on line 115.
- No imports or new methods are needed.
- Functionality remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
