### PR TITLE
Potential fix for code scanning alert no. 45: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/notes/models/sequlz.mjs
+++ b/Chapter13/notes/models/sequlz.mjs
@@ -42,7 +42,9 @@ export async function connectDB() {
                 && process.env.SEQUELIZE_DBDIALECT !== '') {
             params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
         }
-        debug(`connectDB ${util.inspect(params)}`);
+        // Redact sensitive info before logging
+        const redactedParams = { ...params, password: params.password ? '[REDACTED]' : undefined };
+        debug(`connectDB ${util.inspect(redactedParams)}`);
         sequlz = new Sequelize(params.dbname,
                         params.username, params.password,
                         params.params);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/45](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/45)

The best way to fix this problem is to ensure that sensitive fields (such as passwords, secret keys, and any other secrets) are either excluded or redacted before logging configuration objects. In this case, before logging the params object (on line 45), we should create a shallow copy of the object where the `password` (and, optionally, any other sensitive fields like secrets) are replaced with a placeholder value such as `[REDACTED]`. Only the redacted copy should be passed to `util.inspect` for logging. This fix minimizes the risk that sensitive data ends up in the log files, while still allowing non-sensitive connection parameters to be inspected for debugging.

Required changes:  
- Before line 45, create a copy of the params object with `password` replaced by `[REDACTED]`.  
- Use this redacted copy for logging in line 45.
- No additional package is needed—plain JavaScript will suffice.
- Only change the logging—do not alter functionality elsewhere.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
