### PR TITLE
Potential fix for code scanning alert no. 40: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/users/cli.mjs
+++ b/Chapter12/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for user: ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/40](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/40)

The correct way to fix this bug is to ensure passwords (and other sensitive data) are never logged.  
- On line 175 in `Chapter12/users/cli.mjs`, the `console.log` statement should be modified so that it either omits the `password`, or (in rare testing situations) replaces it with a masked value (e.g., replacing the password with `*****`), or simply removes logging of the password altogether. 
- For auditing or debugging, it's acceptable to log that a password check was performed for a username (without logging the actual password).
- No additional methods or third-party imports are required—just remove the sensitive variable from the log output.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
