### PR TITLE
Potential fix for code scanning alert no. 43: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/users/users-sequelize.mjs
+++ b/Chapter12/users/users-sequelize.mjs
@@ -40,7 +40,9 @@ export async function connectDB() {
             && process.env.SEQUELIZE_DBDIALECT !== '') {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
-    log('Sequelize params '+ util.inspect(params));
+    // Sanitize sensitive fields before logging
+    const safeParams = { ...params, password: '[REDACTED]' };
+    log('Sequelize params ' + util.inspect(safeParams));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/43](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/43)

The fix is to ensure that sensitive information such as database passwords are not logged. Instead, before logging, we should sanitize the configuration object to redact the password (and potentially username) property. The recommended practise is to create a shallow copy of the parameters object, and set any sensitive fields (`password`, possibly also `username`) to a constant such as `"[REDACTED]"` before passing the object to the inspect/log statement. The rest of the non-sensitive details can be logged for diagnostic purposes.

Change required:
- In Chapter12/users/users-sequelize.mjs, specifically within the `connectDB` function, replace the existing logging statement (line 43) so that instead of logging `params` directly, it logs a copy where `password` is replaced with `"[REDACTED]"` (and optionally, other secrets). If `params.username` is also sensitive, redact similarly.
- No additional imports are needed, as object spread and util.inspect are already present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
