### PR TITLE
Potential fix for code scanning alert no. 10: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter11/notes/app.mjs
+++ b/Chapter11/notes/app.mjs
@@ -115,7 +115,10 @@ app.use(session({
     secret: sessionSecret,
     resave: true,
     saveUninitialized: true,
-    name: sessionCookieName
+    name: sessionCookieName,
+    cookie: {
+        secure: process.env.NODE_ENV === 'production'
+    }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/10](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/10)

To fix this issue, the best approach is to explicitly set the session cookie's `secure` attribute. This is done by passing a `cookie: { secure: true }` object inside the session middleware options. This ensures that cookies are only sent over HTTPS. However, setting `secure: true` means cookies will not be sent on non-HTTPS connections (which is desirable in production; but can break things during local development). A safe pattern is to set `secure: true` when `process.env.NODE_ENV === 'production'` and possibly allow non-secure cookies during development.  

You should modify the code block where `session(...)` is passed its configuration object (lines 113-119). Edit these lines to add a `cookie` property with `secure` set according to the environment. No extra imports are needed, but you must ensure the `cookie` option is added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
