### PR TITLE
Potential fix for code scanning alert no. 11: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter12/notes/app.mjs
+++ b/Chapter12/notes/app.mjs
@@ -115,7 +115,10 @@ app.use(session({
     secret: sessionSecret,
     resave: true,
     saveUninitialized: true,
-    name: sessionCookieName
+    name: sessionCookieName,
+    cookie: {
+        secure: process.env.NODE_ENV === 'production'
+    }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/11](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/11)

To fix the clear text transmission of sensitive session cookies, the `cookie.secure` property should be set to `true` in the session configuration object. This ensures the session cookie is only sent over encrypted (HTTPS) connections. 

However, during local development (when using HTTP), setting `cookie.secure: true` will prevent the session cookie from being delivered, as it requires HTTPS. To account for both environments, a common practice is to set `cookie.secure` dynamically based on the runtime environment (e.g., based on whether `NODE_ENV` is `'production'` or the server is running over HTTPS).

**Recommended change:**  
Edit the session middleware configuration (line 113) to include a `cookie` object and set its `secure` property to `true` in production (or based on process.env.NODE_ENV). The fix should be added inside the call to `session({ ... })`. This change is local to file `Chapter12/notes/app.mjs`, at the lines where `session()` is configured.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
