### PR TITLE
Potential fix for code scanning alert no. 12: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter13/notes/app.mjs
+++ b/Chapter13/notes/app.mjs
@@ -113,7 +113,10 @@ app.use(session({
     secret: sessionSecret,
     resave: true,
     saveUninitialized: true,
-    name: sessionCookieName
+    name: sessionCookieName,
+    cookie: {
+        secure: process.env.NODE_ENV === "production"
+    }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/12](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/12)

To fix the problem, add the `cookie.secure` attribute in the session middleware configuration. This instructs Express to only transmit the session cookie over HTTPS when `cookie.secure: true`. To avoid breaking development setups that don’t use HTTPS (e.g., localhost), set `cookie.secure` dynamically based on `process.env.NODE_ENV`: true in "production", false otherwise. This preserves current functionality, and only strengthens security for real-world serving environments.

Edit in `Chapter13/notes/app.mjs`, at the session setup lines (lines 111–117).  
You may need to add a `cookie` object to the session configuration if one doesn't exist, and include `secure: process.env.NODE_ENV === "production"`.  

No additional imports, methods, or variable definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
