### PR TITLE
Potential fix for code scanning alert no. 49: Clear-text logging of sensitive information

### DIFF
--- a/Chapter13/users/user-server.mjs
+++ b/Chapter13/users/user-server.mjs
@@ -66,7 +66,9 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        // Redact password before logging update
+        let redacted = { ...toupdate, password: '[REDACTED]' };
+        log(`updating ${util.inspect(redacted)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/49](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/49)

To fix this issue, we should ensure that the password (and any other sensitive fields, if present) are not logged. The best solution is to redact the password before logging the update details. We can accomplish this by making a shallow copy of `toupdate`, replacing its `password` field with a constant such as `[REDACTED]`, and logging that instead. Edits are only needed to the block in `user-server.mjs` that logs `toupdate` during an update operation (currently line 69). No additional imports or method definitions are required, since JavaScript object spread and reassignment are sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
