### PR TITLE
Potential fix for code scanning alert no. 13: Clear text transmission of sensitive cookie

### DIFF
--- a/Chapter14/notes/app.mjs
+++ b/Chapter14/notes/app.mjs
@@ -152,8 +152,10 @@ app.use(session({
     resave: true,
     saveUninitialized: true,
     name: sessionCookieName,
-    secure: true,
-    maxAge: 2 * 60 * 60 * 1000 // 2 hours
+    cookie: {
+        secure: true,
+        maxAge: 2 * 60 * 60 * 1000 // 2 hours
+    }
 }));
 initPassport(app);
 app.use(express.static(path.join(__dirname, 'public')));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/13](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/13)

The correct way to set the Secure (and optionally HttpOnly and SameSite) attributes for cookies in `express-session` is via the `cookie` object in the session configuration. Move the `secure: true` (and optionally add `httpOnly: true` and/or `sameSite: 'lax'`) to the `cookie` subobject of the session configuration. Leave the rest of the session options unchanged.

**Steps:**
- Edit the `session()` middleware configuration inside `app.use(session({...` at line 149 so that the session options have a `cookie: { secure: true, ... }` object.
- Remove any `secure`, `maxAge`, etc. settings from the root level and place them in the `cookie` object as needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
