### PR TITLE
Potential fix for code scanning alert no. 42: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/users/user-server.mjs
+++ b/Chapter12/users/user-server.mjs
@@ -157,7 +157,7 @@ server.post('/password-check', async (req, res, next) => {
     try {
         await connectDB();
         const user = await SQUser.findOne({ where: { username: req.params.username } });
-        log(`userPasswordCheck query=${req.params.username} ${req.params.password} user=${user.username} ${user.password}`);
+        log(`userPasswordCheck query username=${req.params.username} userFound=${!!user}`);
         let checked;
         if (!user) {
             checked = { 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/42](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/42)

To fix this, remove the password from logs entirely. Instead, log only non-sensitive information, such as the username involved in the request and whether the check succeeded or failed. On line 160, never include `req.params.password` or `user.password` in the log. The most direct fix is to update the log line to exclude any password data, just logging the username and possibly the user query result.

Specifically:
- Edit line 160 to log only the username and perhaps indicate a password check attempt.
- No new imports are needed, as the existing `log` and `util` utilities suffice.
- Make sure no other sensitive data is logged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
