### PR TITLE
Potential fix for code scanning alert no. 39: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/users/cli.mjs
+++ b/Chapter12/users/cli.mjs
@@ -127,7 +127,9 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        // Don't log hashed password field.
+        const { password, ...topostSafe } = topost;
+        console.log('update ', topostSafe);
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/39](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/39)

To fix the problem, we should avoid logging the sensitive `password` field from the `topost` object. Instead, we can log a redacted version that excludes the password, or simply indicate the presence of an update without including sensitive fields. 

The best approach is, prior to logging, to construct a new version of the object (or a shallow copy) with the password field removed or set to a dummy value (e.g., `undefined` or `[REDACTED]`). This ensures useful logging without leaking credentials. Specifically:
- In file `Chapter12/users/cli.mjs`, in the `update` command's action callback, replace line 130 so that the logged object does not contain the raw or hashed password.
- No new methods are needed; a shallow object copy minus a sensitive field suffices.
- No new imports are needed as object destructuring is standard JS.
- The fix is just in the logging statement: before calling `console.log`, prepare a copy of `topost` with the password field omitted or replaced.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
