### PR TITLE
Potential fix for code scanning alert no. 38: Clear-text logging of sensitive information

### DIFF
--- a/Chapter12/notes/routes/users.mjs
+++ b/Chapter12/notes/routes/users.mjs
@@ -112,7 +112,7 @@ if (typeof process.env.TWITTER_CONSUMER_KEY !== 'undefined'
 
 if (twitterLogin) {
 
-    console.log(`enable_twitter consumer_key ${consumer_key} consumer_secret ${consumer_secret} ${twittercallback}/users/auth/twitter/callback`);
+    console.log(`Twitter authentication enabled. Callback URL: ${twittercallback}/users/auth/twitter/callback`);
     passport.use(new TwitterStrategy({
         consumerKey: consumer_key,
         consumerSecret: consumer_secret,


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/38](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/38)

To fix this issue, you must remove or mask sensitive values from log statements. In this case, the log on line 115 exposes both the consumer key and secret; these should not appear in any logs. The safest fix is to log only non-sensitive configuration and state information (e.g., log that Twitter authentication is enabled, the callback URL, etc.), but not these secrets. 

Specifically:
- In Chapter12/notes/routes/users.mjs, rewrite or remove the log statement on line 115.
- Ensure that `consumer_key` and `consumer_secret` are *NOT* logged.
- You can still log that Twitter login is enabled, and optionally the callback URL, as these are not secrets.

No additional imports, dependencies, or complex logic is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
