### PR TITLE
Potential fix for code scanning alert no. 37: Clear-text logging of sensitive information

### DIFF
--- a/Chapter11/users/users-sequelize.mjs
+++ b/Chapter11/users/users-sequelize.mjs
@@ -92,7 +92,9 @@ export async function findOneUser(username) {
 
 export async function createUser(req) {
     let tocreate = userParams(req);
-    console.log(`create tocreate ${util.inspect(tocreate)}`);
+    // Do not log sensitive fields such as password
+    const sanitized = { ...tocreate, password: '[REDACTED]' };
+    console.log(`create tocreate ${util.inspect(sanitized)}`);
     await SQUser.create(tocreate);
     const result = await findOneUser(req.params.username);
     return result;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/37](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/37)

To fix this, we should ensure that sensitive fields like `password` are excluded from any logging. The best way is to omit the `password` field when logging `tocreate`. This can be done by creating a shallow copy of `tocreate` with the `password` field explicitly set to a masked value (e.g., `"[REDACTED]"`), or removed altogether, before logging. Only apply this sanitization to the logging statement and do not alter the actual data sent to the database.

The change is within `export async function createUser(req)` in Chapter11/users/users-sequelize.mjs on line 95, replacing the current log statement (`console.log(...)`) with one that logs a sanitized version of `tocreate`.

No additional imports are needed—plain JS object methods are sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
