### PR TITLE
Potential fix for code scanning alert no. 36: Clear-text logging of sensitive information

### DIFF
--- a/Chapter11/users/users-sequelize.mjs
+++ b/Chapter11/users/users-sequelize.mjs
@@ -42,7 +42,9 @@ export async function connectDB() {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
     
-    log('Sequelize params '+ util.inspect(params));
+    // Sanitize sensitive information before logging
+    const sanitizedParams = { ...params, password: '[REDACTED]' };
+    log('Sequelize params ' + util.inspect(sanitizedParams));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/36](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/36)

The best way to fix the problem is to remove the sensitive fields (specifically `password`, but potentially also `username`) from the params object before logging, or to create a sanitized copy for logging. This avoids changing any business logic and only affects log output. The only required edit is to sanitize the object being logged on line 45 in Chapter11/users/users-sequelize.mjs.  
Specifically, before logging, remove or redact sensitive fields from `params` (both top-level and nested if necessary), and log only the sanitized version.  
This can be achieved by making a shallow copy of `params`, replacing/removing the password field, and then logging that copy.

No additional imports are necessary—the code already imports `util` for inspection.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
