### PR TITLE
Potential fix for code scanning alert no. 15: Clear-text logging of sensitive information

### DIFF
--- a/Chapter08/users/cli.mjs
+++ b/Chapter08/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`Performing password check for user: ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/15](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/15)

The problem is that the password, which should be treated as sensitive, is logged in cleartext. The correct fix is to avoid logging the raw password entirely. The line:
```js
console.log(`password check ${username} ${password}`);
```
should be altered to log only the username (or neither parameter), but **never the plain password**. If it's useful to indicate an operation is running, a message such as:
```js
console.log(`Performing password check for user: ${username}`);
```
can be used.

Only the relevant line (175) in `Chapter08/users/cli.mjs` needs to be updated. No new imports, methods, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
