### PR TITLE
Potential fix for code scanning alert no. 33: Clear-text logging of sensitive information

### DIFF
--- a/Chapter11/users/cli.mjs
+++ b/Chapter11/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for user ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/33](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/33)

To fix cleartext logging of sensitive information, we need to stop logging the raw password value. The best fix would be to revise the offending `console.log` so that it does not print the password string, while preserving useful logging for troubleshooting. Printing the `username` alone (or with masked password, or a generic event message) is sufficient for most needs.

**File/region to change:**  
In `Chapter11/users/cli.mjs`, in the handler for the `'password-check <username> <password>'` command (around line 175), change the logging statement so it does not log the password in plaintext. Instead, just log the username or a generic message indicating that a password check is being performed.

**Implementation:**  
Remove the password from the interpolated string. No new libraries or definitions are needed for this minimal change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
