### PR TITLE
Potential fix for code scanning alert no. 68: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter09/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter09/notes/theme/dist/js/bootstrap.bundle.js
@@ -161,7 +161,11 @@
       }
 
       try {
-        return document.querySelector(selector) ? selector : null;
+        if (selector) {
+          var selectedElem = document.querySelector(selector);
+          return selectedElem ? selectedElem : null;
+        }
+        return null;
       } catch (err) {
         return null;
       }
@@ -1143,15 +1147,15 @@
     };
 
     Carousel._dataApiClickHandler = function _dataApiClickHandler(event) {
-      var selector = Util.getSelectorFromElement(this);
+      var target = Util.getSelectorFromElement(this);
 
-      if (!selector) {
+      if (!target) {
         return;
       }
 
-      var target = $(selector)[0];
+      // var target = $(selector)[0];
 
-      if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
+      if (!$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/68](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/68)

To prevent the DOM text from being reinterpreted as HTML, we should avoid using `$(selector)` directly when acting on selectors that could contain arbitrary, attacker-controlled content. Instead, it's safer to only select elements within the context of a known root (e.g., `document`), or to use `document.querySelector` (as is already being checked in `Util.getSelectorFromElement`). 

The best way to fix this is to replace `$(selector)[0]` at line 1152 (and subsequent uses) with a direct reference to the element already obtained safely via `document.querySelector`. Since `Util.getSelectorFromElement(this)` already checks the selector with `document.querySelector(selector)`, we can simply extract the element reference there and pass it (not its selector string) downstream. 

Specifically:
- Modify `Util.getSelectorFromElement` to return the *element* (the result of `document.querySelector(selector)`) rather than the *selector* string.
- Update downstream uses (such as in `_dataApiClickHandler`) to use the element directly, replacing `$(selector)[0]` with the returned DOM node.
- This prevents a tainted selector from being reinterpreted and used as HTML by the jQuery selector engine, blocking the XSS vector.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
