### PR TITLE
Potential fix for code scanning alert no. 34: Clear-text logging of sensitive information

### DIFF
--- a/Chapter11/users/user-server.mjs
+++ b/Chapter11/users/user-server.mjs
@@ -66,7 +66,8 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        const sanitizedUpdate = { ...toupdate, password: '[REDACTED]' };
+        log(`updating ${util.inspect(sanitizedUpdate)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/34](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/34)

The safest and best way to fix this is to avoid logging any sensitive fields, particularly `password`, when logging user records or update payloads. This can be achieved by constructing a "sanitized" version of the update object before logging, in which the `password` field is replaced by a redacted value (e.g., "[REDACTED]"). 

Specifically:
- In Chapter11/users/user-server.mjs, in the `/update-user/:username` route handler, before logging the update payload (`toupdate`), create a clone or shallow copy of `toupdate`, and substitute its `password` field with a placeholder string.
- Only log the sanitized version of the data.
- This pattern is already followed in `createUser` in users-sequelize.mjs (with `{ ...tocreate, password: '[REDACTED]' }`).

No external libraries are needed, as the code is simply replacing a property value in a JS object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
