### PR TITLE
Potential fix for code scanning alert no. 67: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter09/notes/theme/dist/js/bootstrap.js
+++ b/Chapter09/notes/theme/dist/js/bootstrap.js
@@ -1150,9 +1150,9 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
-      if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
+      if (!target || !$(target).classList.contains(ClassName$2.CAROUSEL)) {
         return;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/67](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/67)

To fix the issue, avoid passing user-controlled data directly to `$()` as a selector. Instead, use a safer alternative:  
- Pass the document context or a known ancestor (element) as the context to a method like `querySelector`, or, if jQuery must be used, pass the context as a second parameter to `$()` so that the string is always interpreted as a selector, not as inline HTML.  
- Since `Util.getSelectorFromElement` is only ever expected to return a selector (ie: a #id or class), and at line 1153, we want the corresponding element, simply use `document.querySelector(selector)` rather than `$(selector)[0]` to fetch the element safely.

**Files/Lines to change:**  
- In `Chapter09/notes/theme/dist/js/bootstrap.js`, at line 1153, change `var target = $(selector)[0];` to `var target = document.querySelector(selector);` to avoid interpreting the selector as HTML.

**What's needed:**  
- Just a code edit at the usage site (line 1153), no extra imports/methods are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
