### PR TITLE
Potential fix for code scanning alert no. 32: Clear-text logging of sensitive information

### DIFF
--- a/Chapter11/users/cli.mjs
+++ b/Chapter11/users/cli.mjs
@@ -127,7 +127,9 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        // Do not log password hash
+        const {password, ...topostSansPassword} = topost;
+        console.log('update ', topostSansPassword);
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/32](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/32)

To fix the problem, edit the log statement so that the `password` property of the `topost` object is not logged. The best way is to create a shallow clone of `topost` (or a new object), omitting the `password` property, and log that object instead. This does not affect any functional logic or requests, only the log output.

The only file to edit is `Chapter11/users/cli.mjs`. Find the log statement on line 130 in the `.action` handler for the `update <username>` command. Replace

```js
console.log('update ', topost);
```
with something that logs all of `topost` except the `password`, e.g.:

```js
const {password, ...topostSansPassword} = topost;
console.log('update ', topostSansPassword);
```

No new imports are needed, as this uses standard ES destructuring.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
