### PR TITLE
Potential fix for code scanning alert no. 29: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/user-server.mjs
+++ b/Chapter10/users/user-server.mjs
@@ -147,7 +147,7 @@ server.post('/password-check', async (req, res, next) => {
     try {
         await connectDB();
         const user = await SQUser.findOne({ where: { username: req.params.username } });
-        log(`userPasswordCheck query=${req.params.username} ${req.params.password} user=${user.username} ${user.password}`);
+        log(`userPasswordCheck query.username=${req.params.username} user.username=${user.username}`);
         let checked;
         if (!user) {
             checked = { 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/29](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/29)

The core issue is that sensitive data, specifically user passwords (plaintext via `req.params.password` and hashed via `user.password`), are logged as part of an informational/debug log statement. To fix this, we should **remove sensitive data from the log output**. Logging the username or safe metadata about the operation is acceptable, but passwords should never be included. The best approach is to **exclude both `req.params.password` and `user.password` from the log message** on line 150, leaving only non-sensitive data such as the username or other identifiers as needed for troubleshooting. Only modify the log statement to redact or omit sensitive fields, without altering the function’s core behavior.

You only need to edit line 150 in `Chapter10/users/user-server.mjs`, modifying the log message to avoid including either unread or hashed passwords.

No new methods or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
