### PR TITLE
Potential fix for code scanning alert no. 27: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/cli.mjs
+++ b/Chapter10/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for user ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/27](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/27)

To fix this issue, we should ensure that sensitive data, notably `password`, is not logged or output in cleartext. The safest approach is to simply remove `${password}` from the message (and ideally also avoid logging even the username if unnecessary, unless for audit/debug justified reasons). If we want to keep the log for debugging or traceability, we can indicate that a password check is occurring for the username, but redact the password from output. 

**Recommended detailed fix:**  
- On line 175, remove `${password}` from the log message.
- The new message could be: ``console.log(`password check for user ${username}`);``
- No new imports or additional code is needed.
- Only a 1-line change in this file/code snippet.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
