### PR TITLE
Potential fix for code scanning alert no. 31: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/users-sequelize.mjs
+++ b/Chapter10/users/users-sequelize.mjs
@@ -92,7 +92,9 @@ export async function findOneUser(username) {
 
 export async function createUser(req) {
     let tocreate = userParams(req);
-    console.log(`create tocreate ${util.inspect(tocreate)}`);
+    // Avoid logging sensitive information like passwords
+    let tocreateForLog = { ...tocreate, password: '[REDACTED]' };
+    console.log(`create tocreate ${util.inspect(tocreateForLog)}`);
     await SQUser.create(tocreate);
     const result = await findOneUser(req.params.username);
     return result;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/31](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/31)

To fix this issue, we should prevent clear-text logging of the user's password (and similarly sensitive fields, although in this case, the password is the key concern).  
- The best way is to avoid logging the entire `tocreate` object, or to mask/redact its sensitive fields before logging.
- In this file and the shown code, line 95 is the only place where this object is logged. The simplest and most robust fix is to log only non-sensitive contents (e.g., excluding the `password` field), or at minimum to replace/mask the `password` field with a placeholder (`[REDACTED]` or `undefined`).
- This requires updating the code at line 95 to inspect a copy of the object with the `password` field omitted or redacted.
- No new imports are needed; we can clone the object and set/replace the sensitive field inline.
- Making this edit at line 95 is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
