### PR TITLE
Potential fix for code scanning alert no. 30: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/users-sequelize.mjs
+++ b/Chapter10/users/users-sequelize.mjs
@@ -42,7 +42,9 @@ export async function connectDB() {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
     
-    log('Sequelize params '+ util.inspect(params));
+    // Create a shallow copy of params with password redacted for logging
+    const paramsForLog = { ...params, password: params.password ? "***REDACTED***" : undefined };
+    log('Sequelize params ' + util.inspect(paramsForLog));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/30](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/30)

To fix the problem, the code should never log sensitive parameters such as database passwords, even in debug output. Instead, when logging connection parameters, redact the password value from the object before logging or log only non-sensitive parameters. The best way is to create a shallow copy of the `params` object with the password replaced by a constant string such as `"***REDACTED***"` before logging, ensuring the password never appears in the logs. This change is localized to the log statement (line 45 in `connectDB`). No new method or external library is needed, only standard JavaScript object handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
