### PR TITLE
Potential fix for code scanning alert no. 26: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/cli.mjs
+++ b/Chapter10/users/cli.mjs
@@ -127,7 +127,14 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        console.log('update ', {
+            username: topost.username,
+            familyName: topost.familyName,
+            givenName: topost.givenName,
+            middleName: topost.middleName,
+            emails: topost.emails,
+            photos: topost.photos
+        });
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/26](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/26)

To fix this issue, modify the logging statement so that sensitive information such as the (hashed) password is not logged. It is still acceptable (and often useful for debugging) to log non-sensitive fields such as the username, and perhaps a small subset of the other topost properties. The best way to do this is to construct a new object that omits the sensitive fields, or explicitly select safe fields to log. Only modify the relevant logging statement: do not leak sensitive data elsewhere or alter the business logic.

Specifically, in Chapter10/users/cli.mjs at line 130, change the line:
```js
console.log('update ', topost);
```
to something like:
```js
console.log('update ', { username: topost.username, familyName: topost.familyName, givenName: topost.givenName, middleName: topost.middleName, emails: topost.emails, photos: topost.photos });
```
or, if needed, log just the username or a hand-picked subset of fields that are non-sensitive.

No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
