### PR TITLE
Potential fix for code scanning alert no. 28: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/user-server.mjs
+++ b/Chapter10/users/user-server.mjs
@@ -66,7 +66,10 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        // Sanitize toupdate before logging to avoid clear-text logging of password
+        const safeToUpdate = { ...toupdate };
+        if (safeToUpdate.password) safeToUpdate.password = '[REDACTED]';
+        log(`updating ${util.inspect(safeToUpdate)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/28](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/28)

To address this problem, the logging statement on line 69 in `Chapter10/users/user-server.mjs` must be changed so that sensitive information (in this case, the password field of the `toupdate` object) is never logged. The best approach is to sanitize the `toupdate` object before logging it: create a shallow copy and remove or mask the `password` (and any other potential sensitive fields, like `emails`, if desired) before passing it to `util.inspect`.

Changes needed:
- Edit around line 69: Before logging, create a shallow copy of `toupdate`, remove (or replace with a placeholder, e.g., `"[REDACTED]"`) the `password` property, then log *that* object with `util.inspect`.
- Only the region around the affected log statement needs to be modified: define a variable for the sanitized copy and use it in place of the original in the log line.

No new imports or complex logic are required—just object destructuring or direct property setting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
