### PR TITLE
Potential fix for code scanning alert no. 85: Clear-text logging of sensitive information

### DIFF
--- a/Chapter10/users/users-sequelize.mjs
+++ b/Chapter10/users/users-sequelize.mjs
@@ -42,9 +42,9 @@ export async function connectDB() {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
     
-    // Create a shallow copy of params with password redacted for logging
-    const paramsForLog = { ...params, password: params.password ? "***REDACTED***" : undefined };
-    log('Sequelize params ' + util.inspect(paramsForLog));
+    // Logging only non-sensitive database configuration metadata
+    log('Initializing Sequelize database connection...');
+    
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/85](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/85)

To fix the problem, edit the code so that no sensitive information is logged. This means not just redacting the password but avoiding logging potentially sensitive configuration items such as username and database name—unless absolutely necessary and clearly identified as non-sensitive. The most robust solution is to restrict logged details to non-sensitive metadata (e.g., "Attempting connection to database" or connection parameters excluding credentials).  
Specifically, in `Chapter10/users/users-sequelize.mjs`, on line 47, replace the logging of the full database params object with a limited, non-sensitive message, such as stating only the dialect or host (if safe), or simply "Connecting to database" with no details.

No new imports or method definitions are required for this fix, only the adjustment of the log line at line 47.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
