### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/Chapter09/users/users-sequelize.mjs
+++ b/Chapter09/users/users-sequelize.mjs
@@ -42,7 +42,9 @@ export async function connectDB() {
         params.params.dialect = process.env.SEQUELIZE_DBDIALECT;
     }
     
-    log('Sequelize params '+ util.inspect(params));
+    // Redact sensitive data before logging
+    const safeParams = { ...params, password: '<redacted>' };
+    log('Sequelize params ' + util.inspect(safeParams));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);
     

--- a/Chapter09/users/users-sequelize.mjs
+++ b/Chapter09/users/users-sequelize.mjs
@@ -43,7 +43,7 @@ export async function connectDB() {
     }
     
     // Redact sensitive data before logging
-    const safeParams = { ...params, password: '<redacted>' };
+    const safeParams = redactSensitive(params);
     log('Sequelize params ' + util.inspect(safeParams));
     
     sequlz = new Sequelize(params.dbname, params.username, params.password, params.params);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/24](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/24)

To fix this vulnerability, we should prevent logging the database password in cleartext. The best fix is to redact (remove or mask) sensitive fields such as `password` from the object before logging it.  
- On line 45, before logging the connection `params`, create a shallow copy of `params`, replacing/removing the `password` property, and then log only the redacted object.  
- It’s best to replace `params.password` with a value such as `'<redacted>'` in the object we log; do **not** mutate the original `params`, as it is used in the actual connection.  
- These changes should occur only in the immediate logging statement in the function `connectDB`, i.e., at or just before line 45.
- No new dependencies are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
