### PR TITLE
Potential fix for code scanning alert no. 69: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter10/notes/theme/dist/js/bootstrap.js
+++ b/Chapter10/notes/theme/dist/js/bootstrap.js
@@ -1150,7 +1150,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/69](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/69)

The best way to fix this problem is to **avoid passing untrusted strings directly into `$()`**, as this could result in the string being interpreted as HTML (not a selector), introducing XSS risk.

**Specifically:**  
- Instead of doing `$(selector)[0]`, use `document.querySelector(selector)` which only treats it as a selector (never HTML).
- To maintain compatibility with the existing code using jQuery wrapped nodes, after finding the element with `document.querySelector(selector)`, wrap that with `$` if needed: `$(document.querySelector(selector))`.
- If the selector is not valid (invalid selector, or returns null), skip further processing.

**Changes to make:**  
- In `Carousel._dataApiClickHandler`, replace `var target = $(selector)[0];` with `var target = document.querySelector(selector);`
- All other uses of `$(target)` are safe since `target` is now a DOM Element, not a potentially attacker-controlled string.

No new methods or imports are necessary, as `document.querySelector` is standard.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
