### PR TITLE
Potential fix for code scanning alert no. 70: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter10/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter10/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,7 +1149,7 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
       if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
         return;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/70](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/70)

The best way to fix this issue is to ensure that untrusted DOM-derived values (`data-target`, `href`, etc.) are never passed directly to jQuery's `$()` as the selector parameter, as this causes jQuery to parse the string as HTML if it begins with `<`, allowing DOM injection/XSS. For selectors or element lookups, we should use stricter DOM APIs or jQuery's context-based selector (`.find`) on a known container element, which treats the string strictly as a selector and not as HTML.

In this file, the main risk is line 1152, where:

```js
var target = $(selector)[0];
```

Here, `selector` is potentially tainted. To address the issue:

- Instead of passing `selector` directly to `$()`, use `document.querySelector(selector)` (already used in `getSelectorFromElement`), or refactor to retrieve the element directly via that API.
- So, replace `var target = $(selector)[0];` with simply
  ```js
  var target = document.querySelector(selector);
  ```
This is safe, as it does not interpret the string as HTML but only as a selector.
- Throughout, ensure that subsequent jQuery operations use the resolved element (`$(target)`), never the tainted selector.

Only the highlighted usage (line 1152, and any dependent usages in that block) need to be changed.

No new imports or libraries are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
