### PR TITLE
Potential fix for code scanning alert no. 22: Clear-text logging of sensitive information

### DIFF
--- a/Chapter09/users/user-server.mjs
+++ b/Chapter09/users/user-server.mjs
@@ -64,7 +64,10 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        // Remove or mask password before logging
+        let toupdateSafe = { ...toupdate };
+        if ('password' in toupdateSafe) toupdateSafe.password = '[REDACTED]';
+        log(`updating ${util.inspect(toupdateSafe)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/22](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/22)

Sensitive data such as passwords should never be logged. The logging call on line 67 in `user-server.mjs` should be changed to exclude the password.  
**General fix:** Before logging, create a copy or transformation of `toupdate` that omits or masks the `password` field, and log that version instead.  
**Best way to fix:**  
- On line 67, replace `log(`updating ${util.inspect(toupdate)}`);` with code that creates a shallow copy of `toupdate`, deletes or masks the `password` field, and logs the sanitized object. For example:

```javascript
let toupdateSafe = { ...toupdate };
if ('password' in toupdateSafe) toupdateSafe.password = '[REDACTED]';
log(`updating ${util.inspect(toupdateSafe)}`);
```

- Only edit shown code in `user-server.mjs`; do not edit other files or logic.
- No additional imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
