### PR TITLE
Potential fix for code scanning alert no. 21: Clear-text logging of sensitive information

### DIFF
--- a/Chapter09/users/cli.mjs
+++ b/Chapter09/users/cli.mjs
@@ -172,7 +172,7 @@ program
     .command('password-check <username> <password>')
     .description('Check whether the user password checks out')
     .action((username, password, cmdObj) => {
-        console.log(`password check ${username} ${password}`);
+        console.log(`password check for ${username}`);
         client(program).post('/password-check', { username, password },
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/21](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/21)

To fix the problem, we must ensure that password values are never logged. In the referenced line, the password is included in a log message for the "password-check" command. The correct approach is to log only non-sensitive information such as the username and the operation being performed. Specifically, we should remove the `${password}` portion from the log message on line 175, so sensitive data is excluded. No imports or new methods are needed; this is a straightforward string modification in the logging call.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
