### PR TITLE
Potential fix for code scanning alert no. 19: Clear-text logging of sensitive information

### DIFF
--- a/Chapter08/users/user-server.mjs
+++ b/Chapter08/users/user-server.mjs
@@ -145,7 +145,7 @@ server.post('/password-check', async (req, res, next) => {
     try {
         await connectDB();
         const user = await SQUser.findOne({ where: { username: req.params.username } });
-        log(`userPasswordCheck query=${req.params.username} ${req.params.password} user=${user.username} ${user.password}`);
+        log(`userPasswordCheck query=${req.params.username} user=${user ? user.username : '[not found]'}`);
         let checked;
         if (!user) {
             checked = { 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/19](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/19)

Passwords must never be logged in clear text, nor as hashes. To fix this issue, we should entirely remove `req.params.password` and `user.password` from the logged message on line 148. The logging can still include the username (which is not generally secret), and perhaps whether the queried user was found (without exposing any password material). You may also want to remain careful not to log any other sensitive fields, e.g., email addresses, personally identifying details, etc. The fix only needs to modify the log statement at line 148, potentially filtering the `user` object to exclude sensitive fields if necessary. No new imports or helper functions are required for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
