### PR TITLE
Potential fix for code scanning alert no. 20: Clear-text logging of sensitive information

### DIFF
--- a/Chapter09/users/cli.mjs
+++ b/Chapter09/users/cli.mjs
@@ -127,7 +127,9 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        // Avoid logging sensitive password field
+        const { password, ...topostWithoutPassword } = topost;
+        console.log('update ', topostWithoutPassword);
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/20](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/20)

To fix the problem, we should modify the logging statement to ensure that no sensitive fields—such as passwords (including hashes)—are logged. The safest approach is to log only non-sensitive fields or produce a sanitized copy of the object excluding the password before logging. 

In Chapter09/users/cli.mjs, at line 130, change `console.log('update ', topost);` so that it does not include the password field. We will create a shallow copy of `topost` omitting `password`, and log that sanitized object instead. No changes to functionality are made—only the logged content is altered.

We do not need to add new imports. We'll use basic destructuring to exclude the password.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
