### PR TITLE
Potential fix for code scanning alert no. 17: Clear-text logging of sensitive information

### DIFF
--- a/Chapter08/users/users-sequelize.mjs
+++ b/Chapter08/users/users-sequelize.mjs
@@ -93,7 +93,9 @@ export async function findOneUser(username) {
 
 export async function createUser(req) {
     let tocreate = userParams(req);
-    console.log(`create tocreate ${util.inspect(tocreate)}`);
+    // Avoid logging sensitive information like passwords
+    const { password, ...tocreateSafe } = tocreate;
+    console.log(`create tocreate ${util.inspect(tocreateSafe)}`);
     await SQUser.create(tocreate);
     const result = await findOneUser(req.params.username);
     return result;


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/17](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/17)

The best way to fix this problem is to ensure that sensitive information (such as cleartext passwords or other secrets) is never logged. In this scenario, the log statement should be modified to exclude the password. This can be done by creating a shallow copy of the object and removing/redacting the `password` field before logging it, or by constructing a log message that only includes non-sensitive fields.  
Specifically, in `createUser`, when calling `console.log`, `tocreate` should be sanitized first by either removing or masking the `password` property. Add this sanitation inline in the log or define a helper for it.

Only code inside `Chapter08/users/users-sequelize.mjs` needs to be changed, specifically at the logging point on line 96. No new modules need to be imported for this simple redaction. If necessary, create a local copy of the object that excludes the password for logging. All other object usages should not be affected.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
