### PR TITLE
Potential fix for code scanning alert no. 18: Clear-text logging of sensitive information

### DIFF
--- a/Chapter08/users/user-server.mjs
+++ b/Chapter08/users/user-server.mjs
@@ -64,7 +64,8 @@ server.post('/update-user/:username', async (req, res, next) => {
         log(`update-user params ${util.inspect(req.params)}`);
         await connectDB();
         let toupdate = userParams(req);
-        log(`updating ${util.inspect(toupdate)}`);
+        const { password, ...toupdateSafe } = toupdate; // Remove or mask password
+        log(`updating ${util.inspect(toupdateSafe)}`);
         await SQUser.update(toupdate, { where: { username: req.params.username }});
         const result = await findOneUser(req.params.username);
         log('updated '+ util.inspect(result));


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/18](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/18)

To fix this problem, we need to ensure that sensitive fields such as passwords are never included in log messages. The best way to do this is to exclude the password field (and any other sensitive fields, if applicable) from the object that is passed to the logger. This can be achieved by creating a sanitized copy of the object without the sensitive fields before logging. In this context, the most targeted and non-invasive fix is to construct a shallow copy of the object and remove its `password` property before calling `util.inspect` on it. This change should be made only where logging occurs, namely at the specific log statement on line 67 of `Chapter08/users/user-server.mjs`.

Optionally, for improved maintainability, a utility function could be defined to sanitize objects before logging, but this is not strictly necessary for a one-line fix in the provided code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
