### PR TITLE
Potential fix for code scanning alert no. 14: Clear-text logging of sensitive information

### DIFF
--- a/Chapter08/users/cli.mjs
+++ b/Chapter08/users/cli.mjs
@@ -127,7 +127,9 @@ program
         };
         if (typeof cmdObj.email !== 'undefined') topost.emails.push(cmdObj.email);
 
-        console.log('update ', topost);
+        // Log only non-sensitive fields
+        const { password, ...nonSensitiveTopost } = topost;
+        console.log('update ', nonSensitiveTopost);
         client(program).post(`/update-user/${username}`, topost,
         (err, req, res, obj) => {
             if (err) console.error(err.stack);


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/14](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/14)

To resolve the issue, we must stop logging sensitive fields in the `topost` object. The best solution is to remove the password field (and any similarly sensitive data) before logging the object, or to log only non-sensitive fields. This guarantees that credential information is not written to logs. Concretely, in the action for the `'update <username>'` command, update the logging statement so that it does not output the `password` property.  
Implementation steps:  
- Change line 130 so that only non-sensitive properties are logged.
- This can be done by manually constructing a new object (excluding `password`) or using object destructuring to filter out the sensitive field.
- Alternatively, if only basic identifying information (“username”, etc.) is required, those specific fields should be logged instead.
- No new imports are required for object manipulation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
