### PR TITLE
Potential fix for code scanning alert no. 72: DOM text reinterpreted as HTML

### DIFF
--- a/Chapter11/notes/theme/dist/js/bootstrap.bundle.js
+++ b/Chapter11/notes/theme/dist/js/bootstrap.bundle.js
@@ -1149,9 +1149,9 @@
         return;
       }
 
-      var target = $(selector)[0];
+      var target = document.querySelector(selector);
 
-      if (!target || !$(target).hasClass(ClassName$2.CAROUSEL)) {
+      if (!target || !$(target).classList.contains(ClassName$2.CAROUSEL)) {
         return;
       }
 


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/72](https://github.com/ibiscum/Node.js-Web-Development-Fifth-Edition/security/code-scanning/72)

To address this XSS risk, the best fix is to ensure that data read from the DOM and then passed as a selector into jQuery is not interpreted as HTML and cannot cause injection. This is best achieved by using jQuery's `.find()` API (or similar), which interprets the string strictly as a CSS selector and does not create elements from markup or allow script execution. Alternatively, ensure the attribute cannot start with `<`, or validate the string as a safe CSS selector.  

Specifically, in file `Chapter11/notes/theme/dist/js/bootstrap.bundle.js`, on line 1152, replace `var target = $(selector)[0];` with a call that is guaranteed not to interpret `selector` as HTML. Since the context is a DOM event handler, and the element to act upon is supposed to be found inside the DOM, we should scope the selector search via `.find()` or `document.querySelector`. The best fix is to first select (with jQuery) from the root (e.g., `document`), then `.find(selector)`.

**Implementation steps:**  
- On line 1152: Replace `var target = $(selector)[0];` with `var target = document.querySelector(selector);` (guaranteed to not interpret as HTML), or scope with jQuery as `var target = $(document).find(selector)[0];`.
- Ensure all further uses in the handler work with the result (can use vanilla DOM or wrap in jQuery for class-checks/calling).
- No new imports are needed, as jQuery and vanilla DOM APIs are present.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
